### PR TITLE
fix: support version upgrades

### DIFF
--- a/rds.tf
+++ b/rds.tf
@@ -62,7 +62,7 @@ resource "aws_rds_cluster" "backend_store" {
   cluster_identifier_prefix = var.unique_name
   tags                      = local.tags
   engine                    = "aurora-mysql"
-  engine_version            = "5.7.mysql_aurora.2.07.1"
+  engine_version            = "5.7"
   engine_mode               = "serverless"
   port                      = local.db_port
   db_subnet_group_name      = aws_db_subnet_group.rds.name


### PR DESCRIPTION
`engine_version`  changed to "5.7.mysql_aurora.2.08.3" from "5.7.mysql_aurora.2.07.1" via maintenance. So we want to ignore maintenance upgrades and do not try to downgrade.